### PR TITLE
Respect Rect Offset in TexturePacker Atlases

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -550,11 +550,10 @@ function Resources.getTextureAtlas(luaFilePath, texture)
         local dataFrame = data.frames[i]
         if frame.textureRotated then
             dataFrame.quad = {uv.u0, uv.v0, uv.u0, uv.v1, uv.u1, uv.v1, uv.u1, uv.v0}
-            dataFrame.rect = {0, 0, r.width, r.height}
         else
             dataFrame.quad = {uv.u0, uv.v1, uv.u1, uv.v1, uv.u1, uv.v0, uv.u0, uv.v0}
-            dataFrame.rect = {0, 0, r.width, r.height}
         end
+        dataFrame.rect = {r.x, r.y, r.x + r.width, r.y + r.height}
     end
     cache[luaFilePath] = data
     return data


### PR DESCRIPTION
If a sprite sheet is created using the "Trim" option in TexturePacker, individual sprites can be offset from the original size. To make them appear at the right position in an animation, this offset (namely the `x` and `y` values of the `spriteColorRect`) must be taken into account when setting the deck's rect.

This fixes MoviePlayer animations for me when trimmed sprite frames have different sizes. I also compared the SheetImage sample output before and after my changes and they look the same.
