### PR TITLE
New features to Animation.

### DIFF
--- a/projects/hanappe-samples/src/samples/display/animation_sample.lua
+++ b/projects/hanappe-samples/src/samples/display/animation_sample.lua
@@ -4,6 +4,17 @@ local completeHandler = function(self)
     print("animation complete!")
 end    
 
+local function throttleAnimation()
+    local timer = MOAITimer.new()
+    timer:setSpan(2)
+    timer:start()
+    MOAICoroutine.blockOnAction(timer)
+    anim2:setThrottle(4)
+    -- timer:start()
+    -- MOAICoroutine.blockOnAction(timer)
+    -- anim2:stop()
+end
+
 function onCreate(params)
     layer = Layer {scene = scene}
     
@@ -21,14 +32,10 @@ function onCreate(params)
     sprite4:setLeft(sprite3:getRight() + sprite3:getWidth())
     sprite4:setTop(sprite3:getTop())
 
-    local cf = function(caller)
-        print(caller)
-    end
-    
     anim1 = Animation({sprite1, sprite2}, 1)
         :moveLoc(50, 50, 0)
         :moveRot(0, 0, 180)
-        :moveScl(1, 1, 0):callFunc(cf)
+        :moveScl(1, 1, 0)
         :wait(3)
         :sequence(
             Animation(sprite1, 1):moveScl(-1, -1, 0):moveRot(0, 0, -180):moveLoc(-50, -50, 0),
@@ -55,10 +62,28 @@ function onStart()
     anim2:play()
 
     -- Change animation speed midway
-    local timer = MOAITimer.new()
-    timer:setSpan(3)
-    timer:start()
-    MOAICoroutine.blockOnAction(timer)
-    anim2:setThrottle(2)
+    local thread = MOAICoroutine.new()
+    thread:run(throttleAnimation)
 
+end
+
+function onTouchDown(e)
+    -- if anim1:isRunning() then
+    --     if anim1:isPaused() then
+    --         print('resume')
+    --         anim1:resume()
+    --     else
+    --         print('pause')
+    --         anim1:pause()
+    --     end
+    -- end
+    if anim2:isRunning() then
+        if anim2:isPaused() then
+            print('resume')
+            anim2:resume()
+        else
+            print('pause')
+            anim2:pause()
+        end
+    end
 end


### PR DESCRIPTION
I've made the following changes to hanappe-framework:
- Add abilities to pause and resume animations.
- Change behaviour so that manually stopping an animation will not trigger the onComplete callback.
- Improve response to the changing of throttle, especially if the animation has nested parallel/sequence/loop.
- Update animation_sample.lua to demonstrate the above changes.

Two things require extra attention:
1. It's related to the definition of Animation.isRunning. In my modification, with the introduction of Animation.isPaused, isRunning becomes more like MOAIAction.isActive rather than MOAIAction.isBusy. For example, when an animation, a, is paused, a:isRunning() and a:isPaused() will both return true. This may not be a problem, but I can also understand if someone finds the naming confusing.
2. In the original code, calling stop() on an animation will only stop the currentCommand of each registered context. For example, in the animation sample, calling anim2:stop() will stop the character from translating, but not sprite index animating. I'm not sure what the original intension was, but I find the behaviour strange. So in my modification, calling stop() will stop all registered commands (i.e. in self._commands). The same behaviour applies to pause() and resume().
