### PR TITLE
Give supplied config entries precedence over environment values.

### DIFF
--- a/projects/hanappe-framework/src/hp/core/Application.lua
+++ b/projects/hanappe-framework/src/hp/core/Application.lua
@@ -22,8 +22,8 @@ local super                 = EventDispatcher
 function M:start(config)
 
     local title = config.title
-    local screenWidth = MOAIEnvironment.horizontalResolution or config.screenWidth
-    local screenHeight = MOAIEnvironment.verticalResolution or config.screenHeight
+    local screenWidth = config.screenWidth or MOAIEnvironment.horizontalResolution
+    local screenHeight = config.screenHeight or MOAIEnvironment.verticalResolution 
     local viewScale = config.viewScale or 1
     local viewWidth = screenWidth / viewScale
     local viewHeight = screenHeight / viewScale


### PR DESCRIPTION
In Application.lua, start() should give the entries in the supplied config table precedence over values from the environment.
