### PR TITLE
Improve touch event processing by requiring touch down before touch move and up can be processed. 

### DIFF
--- a/projects/hanappe-framework/src/hp/display/TouchProcessor.lua
+++ b/projects/hanappe-framework/src/hp/display/TouchProcessor.lua
@@ -18,50 +18,65 @@ local EVENT_TOUCH_UP        = Event(Event.TOUCH_UP)
 local EVENT_TOUCH_MOVE      = Event(Event.TOUCH_MOVE)
 local EVENT_TOUCH_CANCEL    = Event(Event.TOUCH_CANCEL)
 
---
-local function getPointByCache(self, e)
-    for i, p in ipairs(self._touchPoints) do
-        if p.idx == e.idx then
-            return p
+-- For the given event, find the cached touch points that correspond based on the index.
+-- @returns a point if in the cache, else nil
+local function getPointByCache(self, event)
+    for index, point in ipairs(self._touchPoints) do
+        if point.idx == event.idx then
+            return point
         end
     end
 end
 
--- 
-local function getPointByEvent(self, e)
+-- For the given event, retrieve a point datastructure. 
+-- The point cache will first be checked, if none a new point will be created.
+-- @returns a point corresponding to the provided event
+local function getPointByEvent(self, event)
     local layer = self._touchLayer
 
-    local p = getPointByCache(self, e) or {}
-    p.idx = e.idx
-    p.tapCount = e.tapCount
-    p.oldX, p.oldY = p.x, p.y
-    p.x, p.y = layer:wndToWorld(e.x, e.y, 0)
-    p.screenX, p.screenY = e.x, e.y
+    local point = getPointByCache(self, event) or {}
+    point.idx = event.idx
+    point.tapCount = event.tapCount
+    point.oldX, point.oldY = point.x, point.y
+    point.x, point.y = layer:wndToWorld(event.x, event.y, 0)
+    point.screenX, point.screenY = event.x, event.y
     
-    if p.oldX and p.oldY then
-        p.moveX = p.x - p.oldX
-        p.moveY = p.y - p.oldY
+    if point.oldX and point.oldY then
+        point.moveX = point.x - point.oldX
+        point.moveY = point.y - point.oldY
     else
-        p.oldX, p.oldY = p.x, p.y
-        p.moveX, p.moveY = 0, 0
+        point.oldX, point.oldY = point.x, point.y
+        point.moveX, point.moveY = 0, 0
     end
     
-    return p
+    return point
 end
 
-local function eventHandle(self, e, o)
+-- Recurse up the child-parent tree of the provided target object and dispatch the event provided.
+local function eventHandle(self, event, target)
     local layer = self._touchLayer
-    while o do
-        if o.isTouchEnabled and not o:isTouchEnabled() then
+    while target do
+        if target.isTouchEnabled and not target:isTouchEnabled() then
             break
         end
-        if o.dispatchEvent then
-            o:dispatchEvent(e)
+        if target.dispatchEvent then
+            target:dispatchEvent(event)
         end
-        if o.getParent then
-            o = o:getParent()
+        if target.getParent then
+            target = target:getParent()
         else
-            o = nil
+            target = nil
+        end
+    end
+end
+
+-- Iterator that iterates over the list of props and strips off last nil element
+local function props(propsList)
+    local i = 0
+    return function()
+        i = i + 1
+        if propsList[i] ~= nil then
+            return i, propsList[i]
         end
     end
 end
@@ -78,8 +93,8 @@ function M:init(layer)
 end
 
 --------------------------------------------------------------------------------
--- イベント発生元を設定します.
--- 典型的には、Sceneインスタンスが設定されます.
+-- Set the source of the events.
+-- Typically, this is an instance of a Scene
 --------------------------------------------------------------------------------
 function M:setEventSource(eventSource)
     if self._eventSource then
@@ -100,145 +115,156 @@ function M:setEventSource(eventSource)
 end
 
 --------------------------------------------------------------------------------
--- イベントソースに対する参照を削除します.
+-- Remove the event source reference
 --------------------------------------------------------------------------------
 function M:dispose()
     self:setEventSource(nil)
 end
 
 --------------------------------------------------------------------------------
--- プロセッサーが有効かどうか設定します.
+-- Set whether the touch processor is enabled or not.
 --------------------------------------------------------------------------------
 function M:setEnabled(value)
     self._enabled = value
 end
 
 --------------------------------------------------------------------------------
--- プロセッサーが有効かどうか返します.
+-- Determine if the processor is enabled.
+-- @returns true if the processor is enabled, false otherwise.
 --------------------------------------------------------------------------------
 function M:isEnabled()
     return self._enabled
 end
 
---------------------------------------------------------------------------------
--- タッチした時のイベント処理を行います.
---------------------------------------------------------------------------------
-function M:touchDownHandler(e)
+----------------------------------------------------------------------------------------------------------------------
+-- Event handler for touch down events.  Touch down events do not have any prerequisite events.
+-- @param event The event to handle
+----------------------------------------------------------------------------------------------------------------------
+function M:touchDownHandler(event)
     if not self:isEnabled() then
         return
     end
     
     local layer = self._touchLayer
 
-    local p = getPointByEvent(self, e)
-    p.touchingProp = layer:getPartition():propForPoint(p.x, p.y, 0)
-    table.insertElement(self._touchPoints, p)
-    
-    local te = table.copy(p, EVENT_TOUCH_DOWN)
-    te.points = self._touchPoints
+    local point = getPointByEvent(self, event)
+    local propsAtPoint = table.pack(layer:getPartition():propListForPoint(point.x, point.y, 0))
+    table.insertElement(self._touchPoints, point)
 
-    if p.touchingProp then
-        eventHandle(self, te, p.touchingProp)
-    end
-    if not te.stoped then
-        layer:dispatchEvent(te)
-    end
-    if te.stoped then
-        e:stop()
+    local touchEvent = table.copy(point, EVENT_TOUCH_DOWN)
+    touchEvent.points = self._touchPoints
+
+    for index, prop in props(propsAtPoint) do
+        prop._touchDown = touchEvent
+        self:dispatchEvent(touchEvent, event, prop)
     end
 end
 
-----------------------------------------------------------------
--- タッチした時のイベント処理を行います.
-----------------------------------------------------------------
-function M:touchUpHandler(e)
+----------------------------------------------------------------------------------------------------------------------
+-- Event handler for touch up events. Touch up events require a touch down event on the object before they can be 
+-- registered.  A touch up event clears out the touch down state of an object.
+-- @param event The event to handle
+----------------------------------------------------------------------------------------------------------------------
+function M:touchUpHandler(event)
     if not self:isEnabled() then
         return
     end
 
     local layer = self._touchLayer
 
-    local p = getPointByEvent(self, e)
-    local te = table.copy(p, EVENT_TOUCH_UP)
-    
-    if p.touchingProp then
-        eventHandle(self, te, p.touchingProp)
+    local point = getPointByEvent(self, event)
+    local touchEvent = table.copy(point, EVENT_TOUCH_UP)
+    local propsAtPoint = table.pack(layer:getPartition():propListForPoint(point.x, point.y, 0))
+
+    for index, prop in props(propsAtPoint) do
+        if prop._touchDown then
+            prop._touchDown = nil
+            self:dispatchEvent(touchEvent, event, prop)
+        end
     end
     
-    local o = layer:getPartition():propForPoint(p.x, p.y, 0)
-    if o and o ~= p.touchingProp then
-        eventHandle(self, te, o)
-    end
-    
-    if not te.stoped then
-        layer:dispatchEvent(te)
-    end
-    if te.stoped then
-        e:stop()
-    end
-    
-    table.removeElement(self._touchPoints, p)
+    table.removeElement(self._touchPoints, point)
 end
 
-----------------------------------------------------------------
--- タッチした時のイベント処理を行います.
-----------------------------------------------------------------
-function M:touchMoveHandler(e)
+----------------------------------------------------------------------------------------------------------------------
+-- Event handler for touch move events. Touch move events require a touch down event on the object before they can be 
+-- registered.  If the touch is moved outside of the object, the object will receive a touch cancel event.
+-- @param event The event to handle
+----------------------------------------------------------------------------------------------------------------------
+function M:touchMoveHandler(event)
     if not self:isEnabled() then
         return
     end
 
     local layer = self._touchLayer
 
-    local p = getPointByEvent(self, e)
-    local te = table.copy(p, EVENT_TOUCH_MOVE)
-    
-    if p.touchingProp then
-        eventHandle(self, te, p.touchingProp)
+    local point = getPointByEvent(self, event)
+    local touchEvent = table.copy(point, EVENT_TOUCH_MOVE)
+    point.props = point.props or {} -- Props affected by the event, used to keep track of touch cancels by moving off prop.
+    local propsAtPoint = table.pack(layer:getPartition():propListForPoint(point.x, point.y, 0))
+
+    for index, prop in props(propsAtPoint) do
+        if prop._touchDown then
+            table.insertElement(point.props, prop)
+            self:dispatchEvent(touchEvent, event, prop)
+        end
     end
-    
-    local o = layer:getPartition():propForPoint(p.x, p.y, 0)
-    if o and o ~= p.touchingProp then
-        eventHandle(self, te, o)
-    end
-    
-    if not te.stoped then
-        layer:dispatchEvent(te)
-    end
-    if te.stoped then
-        e:stop()
-    end
+
+    self:removePropsCancelledByMove(point.props, propsAtPoint, event)
 end
 
-----------------------------------------------------------------
--- タッチした時のイベント処理を行います.
-----------------------------------------------------------------
-function M:touchCancelHandler(e)
+-- Remove props from the event points if the user has moved their finger off of the prop.  The prop no longer
+-- receives the move events and will receive a touch cancel event.
+-- @param eventProps The props that are being tracked
+-- @param currentProps The props that are under the touch currently
+-- @param event The current event that is occurring.
+function M:removePropsCancelledByMove(eventProps, currentProps, event)
+    for index, prop in ipairs(eventProps) do
+        if 0 == table.indexOf(currentProps, prop) then
+            local cancelEvent = EVENT_TOUCH_CANCEL
+            self:dispatchEvent(cancelEvent, event, prop)
+
+            table.removeElement(eventProps, prop)
+            prop._touchDown = nil
+        end
+    end
+end
+----------------------------------------------------------------------------------------------------------------------
+-- Event handler for touch cancel events.  Cancel events can either occur because of application backgrounding (in iOS),
+-- or because the user has moved their finger off the object during touch move. 
+-- @param event The event to handle
+----------------------------------------------------------------------------------------------------------------------
+function M:touchCancelHandler(event)
     if not self:isEnabled() then
         return
     end
 
     local layer = self._touchLayer
 
-    local p = getPointByEvent(self, e)
-    local te = table.copy(p, EVENT_TOUCH_CANCEL)
+    local point = getPointByEvent(self, event)
+    local touchEvent = table.copy(point, EVENT_TOUCH_CANCEL)
     
-    if p.touchingProp then
-        eventHandle(self, te, p.touchingProp)
-    end
-    
-    local o = layer:propForPoint(p.x, p.y, 0)
-    if o and o ~= p.touchingProp then
-        eventHandle(self, te, o)
-    end
-    if not te.stoped then
-        layer:dispatchEvent(te)
-    end
-    if te.stoped then
-        e:stop()
+    local propsAtPoint = table.pack(layer:getPartition():propListForPoint(point.x, point.y, 0))
+
+    for index, prop in props(propsAtPoint) do
+        self:dispatchEvent(touchEvent, event, prop)
     end
     
-    table.removeElement(self._touchPoints, p)
+    table.removeElement(self._touchPoints, point)
+end
+
+-- Handle and dispatch the provided event.
+-- @param touch event that represents the touch event occurring
+-- @param event the Event object
+-- @param prop The prop the event is occuring on.
+function M:dispatchEvent(touchEvent, event, prop)
+    eventHandle(self, touchEvent, prop)
+    if not touchEvent.stoped then
+        self._touchLayer:dispatchEvent(touchEvent)
+    end
+    if touchEvent.stoped then
+        event:stop()
+    end
 end
 
 return M

--- a/projects/hanappe-framework/src/hp/lang/table.lua
+++ b/projects/hanappe-framework/src/hp/lang/table.lua
@@ -12,6 +12,12 @@ if unpack then
     M.unpack = unpack
 end
 
+-- Takes multiple arguments and returns them as a table.
+-- This is useful for interfacing with MOAI API's that return multiple values such as MOAIPartiion:propListForPoint()
+function M.pack(...)
+  return arg
+end
+
 --------------------------------------------------------------------------------
 -- Table decorate is useful for decorating objects
 -- when using tables as classes.


### PR DESCRIPTION
![hanappe-touchprocessing](https://f.cloud.github.com/assets/3893074/294945/140fc666-942d-11e2-8e0b-f52aa95deb07.png)

Improving the touch processing by requiring a touch down on an object
before it can have a touch move or touch up event.  Refactoring the
code, translating comments and adding addition doc comments.  Adding
table.pack utility method for interfacing with api's that return
multiple values.

If you have any questions, please feel free to ask.
