### PR TITLE
Inherit visibility

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -1578,9 +1578,11 @@ function DisplayObject:setParent(parent)
  
     self:clearAttrLink(MOAIColor.INHERIT_COLOR)
     self:clearAttrLink(MOAITransform.INHERIT_TRANSFORM)
+    self:clearAttrLink(MOAIProp.INHERIT_VISIBLE)
     if parent then
         self:setAttrLink(MOAIColor.INHERIT_COLOR, parent, MOAIColor.COLOR_TRAIT)
         self:setAttrLink(MOAITransform.INHERIT_TRANSFORM, parent, MOAITransform.TRANSFORM_TRAIT)
+        self:setAttrLink(MOAIProp.INHERIT_VISIBLE, parent, MOAIProp.ATTR_VISIBLE)
     end
 end
 


### PR DESCRIPTION
As of moai/moai-dev@cf311d50a0330a757bab396a0ce606b905f28a45, visibility can be inherited like color and transformation. I think it would be a good default for DisplayObjects to inherit visibility, too.

Maybe we should wait for a new Moai release before merging this, since the moai commit is not in the current release version (1.4p0).
