### PR TITLE
Fixes a small bug in Flower.TouchHandler

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -3024,6 +3024,7 @@ function TouchHandler:onTouch(e)
     
     -- touch down prop
     if e.type == Event.TOUCH_DOWN then
+        prop2 = nil 
         self.touchProps[e.idx] = prop
     elseif e.type == Event.TOUCH_UP then
         self.touchProps[e.idx] = nil


### PR DESCRIPTION
If a TOUCH_DOWN event triggers a open scene, then the TOUCH_UP will be missed by the touch handler instance. This will cause the next TOUCH_DOWN to call an old touchProps[e.idx]. TOUCH_DOWN should never need to call a touchProps[e.idx].
1. TOUCH_DOWN 1: prop stored in touchProps, Eventhandler opens new scene in overlay mode
2. TOUCH_UP: is handled by the new scene's touch handler
3. Return to old scene
4. TOUCH_DOWN: sends message to current prop and the old one from TOUCH_DOWN 1
