### PR TITLE
Allow hexToRGB to work cross platform

### DIFF
--- a/projects/hanappe-framework/src/hp/lang/string.lua
+++ b/projects/hanappe-framework/src/hp/lang/string.lua
@@ -40,13 +40,13 @@ end
 --------------------------------------------------------------------------------
 function string.hexToRGB( s, returnAsTable )
     if returnAsTable then
-        return  { tonumber ( "0x"..string.sub( s, 2, 3 ) )/255.0,
-                tonumber ( "0x"..string.sub( s, 4, 5 ) )/255.0,
-                tonumber ( "0x"..string.sub( s, 6, 7 ) )/255.0 }
+        return  { tonumber ( string.sub( s, 2, 3 ),16 )/255.0,
+                tonumber ( string.sub( s, 4, 5 ),16 )/255.0,
+                tonumber ( string.sub( s, 6, 7 ),16 )/255.0 }
     else
-        return  tonumber ( "0x"..string.sub( s, 2, 3 ) )/255.0,
-                tonumber ( "0x"..string.sub( s, 4, 5 ) )/255.0,
-                tonumber ( "0x"..string.sub( s, 6, 7 ) )/255.0
+        return  tonumber ( string.sub( s, 2, 3 ),16 )/255.0,
+                tonumber ( string.sub( s, 4, 5 ),16 )/255.0,
+                tonumber ( string.sub( s, 6, 7 ),16 )/255.0
     end
 end
 


### PR DESCRIPTION
use the optional base parameter instead of 0x, the 0x prefix is a gnuism and doesn't work on all implementations of libc. (lua just proxies call to strtod, which not all implementations have the 0x support) This was breaking hanappe mesh on emscripten
