### PR TITLE
Fix default value handling for Camera:init()

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -1928,7 +1928,7 @@ M.Camera = Camera
 -- @param far (option)far plane
 --------------------------------------------------------------------------------
 function Camera:init(ortho, near, far)
-    ortho = ortho ~= nil and ortho or true
+    ortho = ortho == nil and true or ortho
     near = near or 1
     far = far or -1
 


### PR DESCRIPTION
When called with ortho = false, Camera:init() created an ortho camera anyway. Fixed by inverting the and-or-logic.
