### PR TITLE
Reset Cached Event Objects

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -3249,6 +3249,12 @@ function TouchHandler:onTouch(e)
     if prop or prop2 then
         e:stop()
     end
+
+    -- reset properties to free resources used in cached event
+    e2.data = nil
+    e2.prop = nil
+    e2.target = nil
+    e2:setListener(nil, nil)
 end
 
 function TouchHandler:getTouchableProp(e)


### PR DESCRIPTION
When analyzing the memory usage of my game, I found that some unused objects were not garbage collected because they were referenced in `Event` objects that were cached in `EventDispatcher.EVENT_CACHE`, `InputMgr.TOUCH_EVENT`, or `TouchHandler.TOUCH_EVENT`.

While these objects would be garbage collected eventually (when the cached event are reused), I think it would be nicer to reset the events right away.
