### PR TITLE
Reset currentScene after animated scene transition

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -2406,6 +2406,7 @@ function SceneAnimations.fade(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(nextScene:seekColor(1, 1, 1, 1, sec, easeType))
 
     currentScene:setVisible(false)
+    currentScene:setColor(1, 1, 1, 1)
 end
 
 --- Scene animation
@@ -2421,6 +2422,7 @@ function SceneAnimations.crossFade(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(action1)
 
     currentScene:setVisible(false)
+    currentScene:setColor(1, 1, 1, 1)
 end
 
 --- Scene animation
@@ -2445,6 +2447,10 @@ function SceneAnimations.popOut(currentScene, nextScene, params)
     local action1 = currentScene:seekColor(0, 0, 0, 0, sec, easeType)
     local action2 = currentScene:seekScl(0.5, 0.5, 0.5, sec, easeType)
     MOAICoroutine.blockOnAction(action1)
+
+    currentScene:setVisible(false)
+    currentScene:setColor(1, 1, 1, 1)
+    currentScene:setScl(1, 1, 1)
 end
 
 --- Scene animation
@@ -2461,6 +2467,7 @@ function SceneAnimations.slideLeft(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(action1)
 
     currentScene:setVisible(false)
+    currentScene:setPos(0, 0)
     nextScene:setPos(0, 0)
 end
 
@@ -2478,6 +2485,7 @@ function SceneAnimations.slideRight(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(action1)
 
     currentScene:setVisible(false)
+    currentScene:setPos(0, 0)
     nextScene:setPos(0, 0)
 end
 
@@ -2495,6 +2503,7 @@ function SceneAnimations.slideTop(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(action1)
 
     currentScene:setVisible(false)
+    currentScene:setPos(0, 0)
     nextScene:setPos(0, 0)
 end
 
@@ -2512,6 +2521,7 @@ function SceneAnimations.slideBottom(currentScene, nextScene, params)
     MOAICoroutine.blockOnAction(action1)
 
     currentScene:setVisible(false)
+    currentScene:setPos(0, 0)
     nextScene:setPos(0, 0)
 end
 


### PR DESCRIPTION
When using scene transitions that do not "match", e.g. opening a scene with _slideRight_ and closing it with _crossFade_, the original scene was sometimes invisible because it was still outside the screen or completely translucent.
