### PR TITLE
Fixed bug in SheetImage:SheetSize

### DIFF
--- a/projects/flower-library/src/flower.lua
+++ b/projects/flower-library/src/flower.lua
@@ -2603,7 +2603,8 @@ end
 -- @param flipY (option)flipY
 function SheetImage:setSheetSize(sizeX, sizeY, spacing, margin, flipX, flipY)
     local tw, th = self.texture:getSize()
-    local cw, ch = tw / sizeX, th / sizeY
+    local cw, ch = (tw-(margin or 0)) / sizeX- (spacing or 0), 
+        (th - (margin or 0))/ sizeY - (spacing or 0)
     self:setTileSize(cw, ch, spacing, margin, flipX, flipY)
 end
 


### PR DESCRIPTION
The setSheetSize function was not working properly when margin or spacing were non zero and not null :
the cw, ch values did not take the margin and spacing parameters into account when calculating cell height and width.
It works with my own project now, and should not break anything else, but I have not tested it on other samples.
