### PR TITLE
Replaced print statements with MOAILogMgr

### DIFF
--- a/projects/hanappe-framework/src/hp/lang/table.lua
+++ b/projects/hanappe-framework/src/hp/lang/table.lua
@@ -3,6 +3,7 @@
 -- modules that extend functionality of the table.
 --
 --------------------------------------------------------------------------------
+local Logger = require("hp/util/Logger")
 
 local M = {}
 setmetatable(M, {__index = table})
@@ -26,7 +27,7 @@ function M.decorate( src, arg1, arg2 )
                 if not src[k] then
                     src[k] = v
                 elseif src[ k ] ~= v then
-                    print( "ERROR (table.decorate): Extension failed because key "..k.." exists.") 
+                    Logger.debug( "ERROR (table.decorate): Extension failed because key "..k.." exists.") 
                 end   
             end
         end
@@ -34,7 +35,7 @@ function M.decorate( src, arg1, arg2 )
         if not src[arg1] then
             src[arg1] = arg2
         elseif src[ arg1 ] ~= arg2 then
-            print( "ERROR (table.decorate): Extension failed because key "..arg1.." exists.") 
+            Logger.debug( "ERROR (table.decorate): Extension failed because key "..arg1.." exists.")
         end      
     end
 end

--- a/projects/hanappe-framework/src/hp/tmx/TMXMap.lua
+++ b/projects/hanappe-framework/src/hp/tmx/TMXMap.lua
@@ -12,6 +12,7 @@
 
 local class = require("hp/lang/class")
 local table = require("hp/lang/table")
+local Logger = require("hp/util/Logger")
 
 local M = class()
 
@@ -42,15 +43,15 @@ end
 --------------------------------------------------------------------------------
 function M:printDebug()
     -- header
-    print("<TMXMap>")
+    Logger.debug("<TMXMap>")
     
     -- attributes
     for i, attr in ipairs(self.ATTRIBUTE_NAMES) do
         local value = self[attr]
         value = value and value or ""
-        print(attr .. " = " .. value)
+        Logger.debug(attr .. " = " .. value)
     end
-    print("</TMXMap>")
+    Logger.debug("</TMXMap>")
 
 end
 

--- a/projects/hanappe-framework/src/hp/tmx/TMXMapLoader.lua
+++ b/projects/hanappe-framework/src/hp/tmx/TMXMapLoader.lua
@@ -12,6 +12,7 @@ local TMXLayer = require("hp/tmx/TMXLayer")
 local TMXObject = require("hp/tmx/TMXObject")
 local TMXObjectGroup = require("hp/tmx/TMXObjectGroup")
 local ResourceManager = require("hp/manager/ResourceManager")
+local Logger = require("hp/util/Logger")
 
 local M = class()
 
@@ -91,7 +92,7 @@ end
 -- Please do not accessible from the outside.
 --------------------------------------------------------------------------------
 function M:parseNodeMap(node)
-    print("parseNodeMap")
+    Logger.debug("parseNodeMap")
     local map = TMXMap:new()
     self.map = map
 

--- a/projects/hanappe-framework/src/hp/util/Logger.lua
+++ b/projects/hanappe-framework/src/hp/util/Logger.lua
@@ -25,7 +25,11 @@ M.selector[M.LEVEL_DEBUG] = true
 -- Is the target output to the console.
 --------------------------------------------------------------------------------
 M.CONSOLE_TARGET = function(...)
-   print(...)
+   local arg = {...}
+   for _,x in ipairs(arg) do
+	  MOAILogMgr.log(tostring(x).." ")
+   end
+   MOAILogMgr.log("\n")
 end
 
 --------------------------------------------------------------------------------

--- a/projects/hanappe-framework/src/hp/util/Triangulation.lua
+++ b/projects/hanappe-framework/src/hp/util/Triangulation.lua
@@ -2,7 +2,7 @@
 -- Triangulation routine is based on code by <br>
 -- JOHN W. RATCLIFF (jratcliff@verant.com), July 22, 2000 <br>
 --------------------------------------------------------------------------------
-
+local Logger = require("hp/util/logger")
 local M = {}
 
 local EPSILON = 0.0000000001
@@ -15,12 +15,12 @@ local function area( contour )
     local q = 1
     
     while q <= n do
-        print( "n, p,q", n, p, q)
+        Logger.debug( "n, p,q", n, p, q)
         A = A + contour[p].x * contour[q].y - contour[q].x * contour[p].y
         p = q
         q = q + 1
     end
-    print("A=", .5 * A )
+    Logger.debug("A=", .5 * A )
     return .5 * A
 end
 
@@ -116,7 +116,7 @@ function M.process( contour )
         -- if we loop, probably it's a non-simple polygon
         -- (it crosses its own boundary)
         if count < 0 then
-            print("ERROR: Polygon is self-intersecting. Can't triangulate.")
+            Logger.error("ERROR: Polygon is self-intersecting. Can't triangulate.")
             --debugger.printTable( contour, "contour" )
             --debugger.printTable( result, "result" )
             return false


### PR DESCRIPTION
Print statements were being used to log messages. This made using the built in log manager for Moai to control logging only work for non Hanappe-framework code. 

This commit moves all print statements to use your existing logger and made that logger use the MOAILogMgr class. I did not go as far as pushing Logger.error to register the log message as an error message. Instead I placed everything as a Status message. 

This work could be extended by making all logging messages use the default MOAILogMgr class or adding the registration for log messages of different classes.
