### PR TITLE
Lower case logger.lua doesn't work on case-sensitive filesystems

### DIFF
--- a/projects/hanappe-framework/src/hp/util/Triangulation.lua
+++ b/projects/hanappe-framework/src/hp/util/Triangulation.lua
@@ -2,7 +2,7 @@
 -- Triangulation routine is based on code by <br>
 -- JOHN W. RATCLIFF (jratcliff@verant.com), July 22, 2000 <br>
 --------------------------------------------------------------------------------
-local Logger = require("hp/util/logger")
+local Logger = require("hp/util/Logger")
 local M = {}
 
 local EPSILON = 0.0000000001


### PR DESCRIPTION
This is a simple fix, but an important one for those of us using Hanappe in production - case sensitive filenames.
